### PR TITLE
Fix expired token exception

### DIFF
--- a/amplify/backend/api/techcon2022api/src/api_server.dart
+++ b/amplify/backend/api/techcon2022api/src/api_server.dart
@@ -5,13 +5,12 @@ import 'aws_dynamodb.dart';
 import 'http_request.dart';
 
 void main() async {
-  final db = new DynamodbUtil(credentials: await CredentialsUtil.resolve());
-
   final port = int.tryParse(Platform.environment['PORT'] ?? '') ?? 8080;
   final server = await HttpServer.bind(InternetAddress.anyIPv6, port);
   print('API Server is listening at :$port');
 
   await server.forEach((HttpRequest request) async {
+    final db = new DynamodbUtil(credentials: await CredentialsUtil.resolve());
     final resp = request.response;
     final reqBody = await RequestBody.fromHttpRequest(request);
 

--- a/amplify/backend/api/techcon2022api/src/aws_client_credentials.dart
+++ b/amplify/backend/api/techcon2022api/src/aws_client_credentials.dart
@@ -43,11 +43,12 @@ class CredentialsUtil {
     final accessKeyId = respJson['AccessKeyId'] ?? '';
     final secretAccessKey = respJson['SecretAccessKey'] ?? '';
     final token = respJson['Token'] ?? '';
-    final expiration = respJson['Expiration'] ?? '';
+    final expirationJson = respJson['Expiration'] ?? '';
+    final expiration = DateTime.tryParse('$expirationJson');
     if (accessKeyId is! String ||
         secretAccessKey is! String ||
         token is! String ||
-        expiration is! String) {
+        expiration == null) {
       print(
         'CredentialsUtil.resolve: '
         'Unexpected response body $respBody',
@@ -55,9 +56,15 @@ class CredentialsUtil {
       return null;
     }
 
+    print(
+      'CredentialsUtil.resolve: '
+      'expirationJson=$expirationJson '
+      'expiration=${expiration.millisecondsSinceEpoch}',
+    );
+
     return AwsClientCredentials(
       accessKey: accessKeyId,
-      expiration: DateTime.tryParse(expiration),
+      expiration: expiration,
       secretKey: secretAccessKey,
       sessionToken: token,
     );


### PR DESCRIPTION
`400 ExpiredTokenException: The security token included in the request is expired` seems to happen because the ECS task doesn't restart as often as in lambda deployments.
